### PR TITLE
add decimal warning alert

### DIFF
--- a/src/components/SmartContractExecution.js
+++ b/src/components/SmartContractExecution.js
@@ -35,6 +35,10 @@ class SmartContractExecution extends Component {
 
   signTransaction = () => {
     const { from, contractAddress, to, amount, gas, decimal } = this.state
+    if (decimal > 20) {
+      return alert('decimal should be less than 21')
+    }
+
     const data = caver.klay.abi.encodeFunctionCall(
       {
         name: 'transfer',

--- a/src/components/SmartContractExecutionFD.js
+++ b/src/components/SmartContractExecutionFD.js
@@ -35,6 +35,9 @@ class SmartContractExecutionFD extends Component {
 
   signTransaction = async () => {
     const { from, to, amount, contractAddress, gas, decimal } = this.state
+    if (decimal > 20) {
+      return alert('decimal should be less than 21')
+    }
 
     const data = caver.klay.abi.encodeFunctionCall(
       {

--- a/src/components/SmartContractExecutionFDRatio.js
+++ b/src/components/SmartContractExecutionFDRatio.js
@@ -44,6 +44,9 @@ class SmartContractExecutionFDRatio extends Component {
       gas,
       decimal
     } = this.state
+    if (decimal > 20) {
+      return alert('decimal should be less than 21')
+    }
 
     const data = caver.klay.abi.encodeFunctionCall(
       {

--- a/src/components/SmartContractExecutionLegacy.js
+++ b/src/components/SmartContractExecutionLegacy.js
@@ -35,6 +35,10 @@ class SmartContractExecutionLegacy extends Component {
 
   signTransaction = () => {
     const { from, contractAddress, to, amount, gas, decimal } = this.state
+    if (decimal > 20) {
+      return alert('decimal should be less than 21')
+    }
+
     const data = caver.klay.abi.encodeFunctionCall(
       {
         name: 'transfer',


### PR DESCRIPTION
At token transfer pages, when the decimal is more than 20, it doesn't work (there is an issue with caver's big number module). Thus I put a warning alert. 